### PR TITLE
feat: 회원가입 페이지 마크업

### DIFF
--- a/src/components/layout/AuthPageLayout.tsx
+++ b/src/components/layout/AuthPageLayout.tsx
@@ -1,0 +1,19 @@
+import { type ReactElement } from "react";
+
+interface AuthPageLayoutProps {
+  children: ReactElement[];
+}
+
+function AuthPageLayout({ children }: AuthPageLayoutProps): ReactElement {
+  return (
+    <div className="auth-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-6 offset-md-3 col-xs-12">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AuthPageLayout;

--- a/src/components/pages/login/LoginForm.tsx
+++ b/src/components/pages/login/LoginForm.tsx
@@ -14,7 +14,12 @@ function LoginForm({ onSubmit, disabled }: LoginFormProps): ReactElement {
 
   return (
     <form onSubmit={handleSubmit}>
-      <Input type="text" placeholder="Email" name="email" disabled={disabled} />
+      <Input
+        type="email"
+        placeholder="Email"
+        name="email"
+        disabled={disabled}
+      />
       <Input
         type="password"
         placeholder="Password"

--- a/src/components/pages/register/RegisterForm.tsx
+++ b/src/components/pages/register/RegisterForm.tsx
@@ -1,0 +1,46 @@
+import { type FormEventHandler, type ReactElement } from "react";
+import Input from "~/components/common/Input";
+
+interface RegisterFormProps {
+  onSubmit: FormEventHandler<HTMLFormElement>;
+  disabled: boolean;
+}
+
+function RegisterForm({ onSubmit, disabled }: RegisterFormProps): ReactElement {
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    onSubmit(e);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Input
+        type="text"
+        placeholder="Your Name"
+        name="username"
+        disabled={disabled}
+      />
+      <Input
+        type="email"
+        placeholder="Email"
+        name="email"
+        disabled={disabled}
+      />
+      <Input
+        type="password"
+        placeholder="Password"
+        name="password"
+        disabled={disabled}
+      />
+      <button
+        className="btn btn-lg btn-primary pull-xs-right"
+        type="submit"
+        disabled={disabled}
+      >
+        Sign up
+      </button>
+    </form>
+  );
+}
+
+export default RegisterForm;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement, type FormEventHandler } from "react";
 import { Link } from "react-router-dom";
+import AuthPageLayout from "~/components/layout/AuthPageLayout";
 import LoginForm from "../components/pages/login/LoginForm";
 import ErrorMessage from "../components/common/ErrorMessage";
 
@@ -13,20 +14,14 @@ function Login(): ReactElement {
   };
 
   return (
-    <div className="auth-page">
-      <div className="container page">
-        <div className="row">
-          <div className="col-md-6 offset-md-3 col-xs-12">
-            <h1 className="text-xs-center">Sign in</h1>
-            <p className="text-xs-center">
-              <Link to="/register">Need an account?</Link>
-            </p>
-            <ErrorMessage message="error" />
-            <LoginForm onSubmit={handleSubmit} disabled={false} />
-          </div>
-        </div>
-      </div>
-    </div>
+    <AuthPageLayout>
+      <h1 className="text-xs-center">Sign in</h1>
+      <p className="text-xs-center">
+        <Link to="/register">Need an account?</Link>
+      </p>
+      <ErrorMessage message="error" />
+      <LoginForm onSubmit={handleSubmit} disabled={false} />
+    </AuthPageLayout>
   );
 }
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,5 +1,6 @@
 import { type FormEventHandler, type ReactElement } from "react";
 import { Link } from "react-router-dom";
+import AuthPageLayout from "~/components/layout/AuthPageLayout";
 import RegisterForm from "~/components/pages/register/RegisterForm";
 import ErrorMessage from "../components/common/ErrorMessage";
 
@@ -14,21 +15,14 @@ function Register(): ReactElement {
   };
 
   return (
-    <div className="auth-page">
-      <div className="container page">
-        <div className="row">
-          <div className="col-md-6 offset-md-3 col-xs-12">
-            <h1 className="text-xs-center">Sign up</h1>
-            <p className="text-xs-center">
-              <Link to="/login">Have an account?</Link>
-            </p>
-
-            <ErrorMessage />
-            <RegisterForm onSubmit={handleSubmit} disabled={false} />
-          </div>
-        </div>
-      </div>
-    </div>
+    <AuthPageLayout>
+      <h1 className="text-xs-center">Sign up</h1>
+      <p className="text-xs-center">
+        <Link to="/login">Have an account?</Link>
+      </p>
+      <ErrorMessage />
+      <RegisterForm onSubmit={handleSubmit} disabled={false} />
+    </AuthPageLayout>
   );
 }
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,7 +1,35 @@
-import { type ReactElement } from "react";
+import { type FormEventHandler, type ReactElement } from "react";
+import { Link } from "react-router-dom";
+import RegisterForm from "~/components/pages/register/RegisterForm";
+import ErrorMessage from "../components/common/ErrorMessage";
 
 function Register(): ReactElement {
-  return <div>Register</div>;
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    const {
+      username: { value: name },
+      email: { value: email },
+      password: { value: password },
+    } = e.currentTarget;
+    console.log(name, email, password);
+  };
+
+  return (
+    <div className="auth-page">
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-6 offset-md-3 col-xs-12">
+            <h1 className="text-xs-center">Sign up</h1>
+            <p className="text-xs-center">
+              <Link to="/login">Have an account?</Link>
+            </p>
+
+            <ErrorMessage />
+            <RegisterForm onSubmit={handleSubmit} disabled={false} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default Register;


### PR DESCRIPTION
## Summary
회원가입 페이지 마크업
## Describe your changes
- `RegisterForm` 컴포넌트 구현
- 로그인/회원가입 페이지 공통 레이아웃 컴포넌트로 분리
- 로그인 페이지 내 이메일 input 태그 `type` text에서 email로 수정
## Issue number and link
closes #13 
