### PR TITLE
feat: 회원 정보 갱신 API 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "jest --watch",
     "lint": "eslint .",
-    "postinstall": "husky install"
+    "postinstall": "husky install",
+    "jest:debug": "yarn run --inspect-brk jest --runInBand"
   },
   "lint-staged": {
     "src/**/*.{js,ts,jsx,tsx}": [

--- a/src/__test__/Setting.test.tsx
+++ b/src/__test__/Setting.test.tsx
@@ -1,0 +1,165 @@
+import { HashRouter } from "react-router-dom";
+import Settings from "~/pages/Settings";
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import InitUser from "~/test-utils/InitUser";
+import userAtom from "~/recoil/atoms/userState";
+import MOCK_USER from "~/test_data/user";
+import server from "~/mocks/server";
+import { rest } from "msw";
+import { baseUrl } from "~/mocks/handlers";
+import { renderWithRecoil, RecoilObserver } from "../test-utils/recoilWrapper";
+
+const navigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => navigate,
+}));
+
+test("로그인한 사용자일 때 설정 페이지 초기 렌더링", () => {
+  const BEFORE_USER = {
+    image: "image",
+    username: "test",
+    bio: "bio",
+    email: "test@test",
+    token: "token",
+  };
+
+  renderWithRecoil(
+    <HashRouter>
+      <InitUser user={BEFORE_USER} />
+      <Settings />
+    </HashRouter>
+  );
+
+  const image = screen.getByPlaceholderText<HTMLInputElement>(/picture/i);
+  const username = screen.getByPlaceholderText<HTMLInputElement>(/name/i);
+  const bio = screen.getByPlaceholderText<HTMLInputElement>(/bio/i);
+  const email = screen.getByPlaceholderText<HTMLInputElement>(/email/i);
+  const password = screen.getByPlaceholderText<HTMLInputElement>(/password/i);
+  const submitButton = screen.getByRole("button", { name: /update/i });
+  const logoutButton = screen.getByRole("button", { name: /logout/i });
+
+  expect(image.value).toBe(BEFORE_USER.image);
+  expect(username.value).toBe(BEFORE_USER.username);
+  expect(bio.value).toBe(BEFORE_USER.bio);
+  expect(email.value).toBe(BEFORE_USER.email);
+  expect(password.value).toBe("");
+  expect(submitButton).toBeEnabled();
+  expect(logoutButton).toBeEnabled();
+});
+
+test("로그인하지 않은 사용자일 때 설정 페이지 초기 렌더링", () => {
+  renderWithRecoil(
+    <HashRouter>
+      <Settings />
+    </HashRouter>
+  );
+
+  const image = screen.queryByPlaceholderText<HTMLInputElement>(/picture/i);
+  const username = screen.queryByPlaceholderText<HTMLInputElement>(/name/i);
+  const bio = screen.queryByPlaceholderText<HTMLInputElement>(/bio/i);
+  const email = screen.queryByPlaceholderText<HTMLInputElement>(/email/i);
+  const password = screen.queryByPlaceholderText<HTMLInputElement>(/password/i);
+  const submitButton = screen.queryByRole("button", { name: /update/i });
+  const logoutButton = screen.queryByRole("button", { name: /logout/i });
+
+  expect(image).not.toBeInTheDocument();
+  expect(username).not.toBeInTheDocument();
+  expect(bio).not.toBeInTheDocument();
+  expect(email).not.toBeInTheDocument();
+  expect(password).not.toBeInTheDocument();
+  expect(submitButton).not.toBeInTheDocument();
+  expect(logoutButton).not.toBeInTheDocument();
+
+  expect(navigate).toHaveBeenCalledWith("/");
+});
+
+test("회원 정보 갱신 성공", async () => {
+  const BEFORE_USER = {
+    image: "image",
+    username: "test",
+    bio: "bio",
+    email: "test@test",
+    token: "token",
+  };
+
+  const AFTER_USER = {
+    image: "updated image",
+    username: "updatedUsername",
+    bio: "updated bio",
+    email: "updated@email",
+    token: MOCK_USER.token,
+  };
+
+  server.resetHandlers(
+    rest.put(baseUrl("/user"), async (req, res, ctx) => {
+      const {
+        user: { image, username, email, bio },
+      } = await req.json();
+
+      const updatedUser = {
+        image: image ?? MOCK_USER.image,
+        username: username ?? MOCK_USER.username,
+        email: email ?? MOCK_USER.email,
+        bio: bio ?? MOCK_USER.bio,
+        token: MOCK_USER.token,
+      };
+
+      return await res(ctx.delay(1000), ctx.json({ user: updatedUser }));
+    })
+  );
+
+  const handleUserChange = jest.fn();
+
+  renderWithRecoil(
+    <HashRouter>
+      <InitUser user={BEFORE_USER} />
+      <RecoilObserver node={userAtom} onChange={handleUserChange} />
+      <Settings />
+    </HashRouter>
+  );
+
+  const user = userEvent.setup();
+
+  const topLevelFieldSet = screen.getAllByRole("group")[0];
+  const image = screen.getByPlaceholderText<HTMLInputElement>(/picture/i);
+  const username = screen.getByPlaceholderText<HTMLInputElement>(/name/i);
+  const bio = screen.getByPlaceholderText<HTMLInputElement>(/bio/i);
+  const email = screen.getByPlaceholderText<HTMLInputElement>(/email/i);
+  const password = screen.getByPlaceholderText<HTMLInputElement>(/password/i);
+  const submitButton = screen.getByRole("button", { name: /update/i });
+
+  await user.clear(image);
+  await user.type(image, AFTER_USER.image);
+
+  await user.clear(username);
+  await user.type(username, AFTER_USER.username);
+
+  await user.clear(bio);
+  await user.type(bio, AFTER_USER.bio);
+
+  await user.clear(email);
+  await user.type(email, AFTER_USER.email);
+
+  await user.clear(password);
+  await user.type(password, "123");
+
+  await act(async () => {
+    await user.click(submitButton);
+  });
+
+  expect(topLevelFieldSet).toBeDisabled();
+
+  await waitFor(
+    () => {
+      expect(handleUserChange).toHaveBeenLastCalledWith(AFTER_USER);
+    },
+    { timeout: 2000 }
+  );
+  expect(navigate).toHaveBeenLastCalledWith(`/${AFTER_USER.username}`);
+
+  await waitFor(() => {
+    expect(topLevelFieldSet).toBeEnabled();
+  });
+});

--- a/src/api/services/user.ts
+++ b/src/api/services/user.ts
@@ -8,7 +8,8 @@ export type LoginUserRequest = {
 export type RegisterUserRequest = LoginUserRequest & {
   username: string;
 };
-type UpdateUserRequest = Partial<User>;
+export type UpdateUserRequest = RegisterUserRequest &
+  Pick<User, "bio" | "image">;
 export type UserResponse = { user: User };
 
 const userApi = {
@@ -22,7 +23,7 @@ const userApi = {
     return await auth.post<UserResponse>("/user");
   },
   async updateUser(payload: UpdateUserRequest) {
-    return await auth.post<UserResponse>("/user", { user: payload });
+    return await auth.put<UserResponse>("/user", { user: payload });
   },
 };
 

--- a/src/components/pages/settings/SettingForm.tsx
+++ b/src/components/pages/settings/SettingForm.tsx
@@ -6,12 +6,17 @@ import { type User } from "~/types";
 interface SettingFormProps {
   user: User;
   onSubmit: FormEventHandler<HTMLFormElement>;
+  disabled: boolean;
 }
 
-function SettingForm({ user, onSubmit }: SettingFormProps): ReactElement {
+function SettingForm({
+  user,
+  onSubmit,
+  disabled,
+}: SettingFormProps): ReactElement {
   return (
     <form onSubmit={onSubmit}>
-      <fieldset>
+      <fieldset disabled={disabled}>
         <Input
           type="text"
           placeholder="URL of profile picture"

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,16 +1,17 @@
 import { rest } from "msw";
 import { BASE_URL } from "~/api/base";
-import {
-  type LoginUserRequest,
-  type RegisterUserRequest,
-} from "~/api/services/user";
 import MOCK_USER from "~/test_data/user";
 
 // https://github.com/mswjs/msw/issues/397#issuecomment-751230924
 export const baseUrl = (path: string): string => BASE_URL + path;
 
+const UnauthorizedErrorBody = {
+  status: "error",
+  message: "missing authorization credentials",
+};
+
 const handlers = [
-  rest.post<RegisterUserRequest>(baseUrl("/users"), async (req, res, ctx) => {
+  rest.post(baseUrl("/users"), async (req, res, ctx) => {
     const {
       user: { username, email, password },
     } = await req.json();
@@ -39,33 +40,60 @@ const handlers = [
       })
     );
   }),
-  rest.post<LoginUserRequest>(
-    baseUrl("/users/login"),
-    async (req, res, ctx) => {
-      const {
-        user: { email, password },
-      } = await req.json();
+  rest.post(baseUrl("/users/login"), async (req, res, ctx) => {
+    const {
+      user: { email, password },
+    } = await req.json();
 
-      const errorResponse: Record<string, string> = {};
-      if (email === "") {
-        errorResponse.email = "can't be blank";
-        return await res(ctx.status(422), ctx.json({ errors: errorResponse }));
-      }
-      if (password === "") {
-        errorResponse.password = "can't be blank";
-        return await res(ctx.status(422), ctx.json({ errors: errorResponse }));
-      }
-
-      return await res(
-        ctx.json({
-          user: {
-            ...MOCK_USER,
-            email,
-          },
-        })
-      );
+    const errorResponse: Record<string, string> = {};
+    if (email === "") {
+      errorResponse.email = "can't be blank";
+      return await res(ctx.status(422), ctx.json({ errors: errorResponse }));
     }
-  ),
+    if (password === "") {
+      errorResponse.password = "can't be blank";
+      return await res(ctx.status(422), ctx.json({ errors: errorResponse }));
+    }
+
+    return await res(
+      ctx.json({
+        user: {
+          ...MOCK_USER,
+          email,
+        },
+      })
+    );
+  }),
+  rest.put(baseUrl("/user"), async (req, res, ctx) => {
+    if (!hasToken(req.headers)) {
+      return await res(ctx.status(401), ctx.json(UnauthorizedErrorBody));
+    }
+
+    const {
+      user: { image, username, email, bio },
+    } = await req.json();
+
+    const updatedUser = {
+      image: image ?? MOCK_USER.image,
+      username: username ?? MOCK_USER.username,
+      email: email ?? MOCK_USER.email,
+      bio: bio ?? MOCK_USER.bio,
+      token: MOCK_USER.token,
+    };
+
+    return await res(ctx.json({ user: updatedUser }));
+  }),
 ];
 
 export default handlers;
+
+function hasToken(headers: Headers): boolean {
+  const prefix = "Token ";
+  const authorization = headers.get("Authorization");
+  if (authorization === null || !authorization.startsWith(prefix)) {
+    return false;
+  }
+
+  const token = authorization.substring(prefix.length);
+  return token !== "";
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,26 +1,43 @@
-import { type FormEventHandler, type ReactElement } from "react";
-import user from "~/test_data/user";
+import { type ReactElement } from "react";
 import SettingForm from "~/components/pages/settings/SettingForm";
 import { useNavigate } from "react-router-dom";
+import { useRecoilState } from "recoil";
+import userAtom from "~/recoil/atoms/userState";
+import userApi, { type UpdateUserRequest } from "~/api/services/user";
+import useForm from "~/hooks/useForm";
+import { type ElementsWith } from "../types/utilType";
 
-function Settings(): ReactElement {
+function Settings(): ReactElement | null {
   const navigate = useNavigate();
-
-  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+  const [user, setUser] = useRecoilState(userAtom);
+  const { isLoading, handleSubmit } = useForm(async (e) => {
     e.preventDefault();
+
     const {
       image: { value: image },
       username: { value: username },
       bio: { value: bio },
       email: { value: email },
       password: { value: password },
-    } = e.currentTarget;
-    console.log(image, username, bio, email, password);
-  };
+    } = e.currentTarget.elements as ElementsWith<UpdateUserRequest>;
+
+    const {
+      data: { user: updatedUser },
+    } = await userApi.updateUser({ image, username, bio, email, password });
+
+    setUser(updatedUser);
+    navigate(`/${updatedUser.username}`);
+  });
+
   const handleLogout = (): void => {
-    // session clear
+    setUser(null);
     navigate("/");
   };
+
+  if (user === null) {
+    navigate("/");
+    return null;
+  }
 
   return (
     <div className="settings-page">
@@ -28,7 +45,11 @@ function Settings(): ReactElement {
         <div className="row">
           <div className="col-md-6 offset-md-3 col-xs-12">
             <h1 className="text-xs-center">Your Settings</h1>
-            <SettingForm user={user} onSubmit={handleSubmit} />
+            <SettingForm
+              user={user}
+              onSubmit={handleSubmit}
+              disabled={isLoading}
+            />
             <hr />
             <button
               className="btn btn-outline-danger"

--- a/src/test-utils/InitUser.tsx
+++ b/src/test-utils/InitUser.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { type User } from "~/types";
+import storage from "~/utils/storage";
+import { useSetRecoilState } from "recoil";
+import userAtom from "~/recoil/atoms/userState";
+
+interface InitUserProps {
+  user: User;
+}
+
+function InitUser({ user }: InitUserProps): null {
+  const setUser = useSetRecoilState(userAtom);
+
+  useEffect(() => {
+    const { token } = user;
+    storage("local").setItem("token", token);
+    setUser(user);
+  }, [user, setUser]);
+
+  return null;
+}
+
+export default InitUser;


### PR DESCRIPTION
## Summary
회원 정보 갱신 API 연결

## Describe your changes
- 회원 정보 갱신 API 잘못된 매개변수 타입, http 메서드 수정
- 회원 정보 갱신 API mocking
- 인증 필요한 페이지 테스트 시, 사용자 설정하는 컴포넌트(`InitUser`)구현
- 설정 페이지 테스트 코드 작성

## Issue number and link
closes #30 
